### PR TITLE
Fix incorrect Gradle command

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@ $ yolo mvn package # runs mvn package -DskipTests
 ```
 
 ```bash
-$ yolo gradle build # runs gradle build -X test
+$ yolo gradle build # runs gradle build -x test
 ```
 
 ## Installation

--- a/yolo.go
+++ b/yolo.go
@@ -28,7 +28,7 @@ func main() {
     }
 
     gradleAdditions := []string {
-        "-X",
+        "-x",
         "test",
     }
 


### PR DESCRIPTION
The code was using `-X`, but the correct flag in Gradle is `-x`.

Note, however, that this `yolo` command is actually redundant in Gradle, since you can simply run `./gradlew assemble`, which would do exactly what you want: because Gradle doesn't have a single lifecycle, there is a built-in command to build everything without tests: see https://melix.github.io/blog/2018/09/gradle-lifecycle.html

I reckon, however, that a real cow-boy should try to perform a _release_ without running tests. In which case, `yolo` will help.